### PR TITLE
Add maven-gpg-plugin configuration to build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <projectAsmVersion>5.0.3</projectAsmVersion>
+    <gpg.skip>true</gpg.skip>
   </properties>
 
   <dependencies>
@@ -252,6 +253,20 @@
             </manifestEntries>
           </archive>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.4</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Having trouble getting the GPG signing to work right for deploying without this. This is how our other projects do it, so I think this should work.