### PR TITLE
Fix copyright header on AllocationClassAdapter.

### DIFF
--- a/src/main/java/com/google/monitoring/runtime/instrumentation/AllocationClassAdapter.java
+++ b/src/main/java/com/google/monitoring/runtime/instrumentation/AllocationClassAdapter.java
@@ -1,4 +1,18 @@
-// Copyright 2009 Google Inc. All Rights Reserved.
+/*
+ * Copyright (C) 2009 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.google.monitoring.runtime.instrumentation;
 


### PR DESCRIPTION
I assume this was supposed to have the Apache 2.0 header.