### PR TITLE
Moved the replace call from the bytecode to the sampler

### DIFF
--- a/src/main/java/com/google/monitoring/runtime/instrumentation/AllocationMethodAdapter.java
+++ b/src/main/java/com/google/monitoring/runtime/instrumentation/AllocationMethodAdapter.java
@@ -147,13 +147,6 @@ class AllocationMethodAdapter extends MethodVisitor {
     super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/lang/Class",
         "getName", "()Ljava/lang/String;", false);
     // -> stack: ... class classNameDotted
-    super.visitLdcInsn('.');
-    // -> stack: ... class classNameDotted '.'
-    super.visitLdcInsn('/');
-    // -> stack: ... class classNameDotted '.' '/'
-    super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/lang/String",
-        "replace", "(CC)Ljava/lang/String;", false);
-    // -> stack: ... class className
   }
 
   // Helper method to compute the product of an integer array and push it on

--- a/src/main/java/com/google/monitoring/runtime/instrumentation/AllocationRecorder.java
+++ b/src/main/java/com/google/monitoring/runtime/instrumentation/AllocationRecorder.java
@@ -231,6 +231,10 @@ public class AllocationRecorder {
     // optional samplers.  However, you don't need the optional samplers in
     // the common case, so I thought I'd save some space.
 
+    if (count >= 0) {
+      desc = desc.replace('.', '/');
+    }
+
     // Copy value into local variable to prevent NPE that occurs when
     // instrumentation field is set to null by this class's shutdown hook
     // after another thread passed the null check but has yet to call


### PR DESCRIPTION
The call to String.replace can allocate memory and it has a chance of tripping
the allocated threshold and showing up on the allocation hotspots.

This CL moves the replace call to the sampler but is only done for array
allocations.

It is a lesser evil of a solution because the replace is only done for
reflective allocations but still only does the added useless replace call for
array solutions.