### PR TITLE
Update Guava version to 23.5.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>20.0</version>
+      <version>23.5-android</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -259,6 +259,7 @@
           </execution>
         </executions>
         <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
           <artifactSet>
             <includes>
               <include>org.ow2.asm:asm</include>
@@ -269,25 +270,25 @@
               <include>org.ow2.asm:asm-xml</include>
               <include>com.google.guava:guava</include>
             </includes>
-	  </artifactSet>
-	  <filters>
-	    <filter>
-	      <artifact>*:*</artifact>
-	      <excludes>
-		<exclude>META-INF/module-info.class</exclude>
-	      </excludes>
-	    </filter>
-	  </filters>
-	  <relocations>
-	      <relocation>
-		<pattern>com.google.common.</pattern>
-		<shadedPattern>com.google.monitoring.runtime.instrumentation.common.</shadedPattern>
-	      </relocation>
-	      <relocation>
-		<pattern>org.objectweb.asm.</pattern>
-		<shadedPattern>com.google.monitoring.runtime.instrumentation.asm.</shadedPattern>
-	      </relocation>
-	    </relocations>
+          </artifactSet>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/module-info.class</exclude>
+              </excludes>
+            </filter>
+          </filters>
+          <relocations>
+            <relocation>
+              <pattern>com.google.common.</pattern>
+              <shadedPattern>com.google.monitoring.runtime.instrumentation.common.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.objectweb.asm.</pattern>
+              <shadedPattern>com.google.monitoring.runtime.instrumentation.asm.</shadedPattern>
+            </relocation>
+          </relocations>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
The -android flavor of Guava is used simply because it's the least common denominator; anything built against it can be run against the -jre flavor, but the reverse is not true.

Also replace some tabs with spaces in the pom.xml file for consistency and set createDependencyReducedPom to false for the shade plugin so it doesn't create a dependency-reduced-pom.xml file that git sees as untracked. I'm not clear on what the purpose of that file is, but even if it has a purpose, as long as we aren't checking it in to the repository I don't think there's a reason to generate it.