### PR TITLE
CVE-2022-42920 update bcel to 6.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>org.apache.bcel</groupId>
       <artifactId>bcel</artifactId>
-      <version>6.0</version>
+      <version>6.6.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
https://github.com/google/allocation-instrumenter/issues/47