### PR TITLE
feat: update to actually use ASM9

### DIFF
--- a/src/main/java/com/google/monitoring/runtime/instrumentation/AllocationClassAdapter.java
+++ b/src/main/java/com/google/monitoring/runtime/instrumentation/AllocationClassAdapter.java
@@ -32,7 +32,7 @@ class AllocationClassAdapter extends ClassVisitor {
   private final String recorderMethod;
 
   public AllocationClassAdapter(ClassVisitor cv, String recorderClass, String recorderMethod) {
-    super(Opcodes.ASM7, cv);
+    super(Opcodes.ASM9, cv);
     this.recorderClass = recorderClass;
     this.recorderMethod = recorderMethod;
   }

--- a/src/main/java/com/google/monitoring/runtime/instrumentation/AllocationMethodAdapter.java
+++ b/src/main/java/com/google/monitoring/runtime/instrumentation/AllocationMethodAdapter.java
@@ -110,7 +110,7 @@ class AllocationMethodAdapter extends MethodVisitor {
 
   /** A new AllocationMethodAdapter is created for each method that gets visited. */
   public AllocationMethodAdapter(MethodVisitor mv, String recorderClass, String recorderMethod) {
-    super(Opcodes.ASM7, mv);
+    super(Opcodes.ASM9, mv);
     this.recorderClass = recorderClass;
     this.recorderMethod = recorderMethod;
   }

--- a/src/main/java/com/google/monitoring/runtime/instrumentation/ConstructorInstrumenter.java
+++ b/src/main/java/com/google/monitoring/runtime/instrumentation/ConstructorInstrumenter.java
@@ -145,7 +145,7 @@ public class ConstructorInstrumenter implements ClassFileTransformer {
     Class<?> cl;
 
     ConstructorMethodAdapter(MethodVisitor mv, Class<?> cl) {
-      super(Opcodes.ASM7, mv);
+      super(Opcodes.ASM9, mv);
       this.cl = cl;
     }
 
@@ -226,7 +226,7 @@ public class ConstructorInstrumenter implements ClassFileTransformer {
     Class<?> cl;
 
     public ConstructorClassAdapter(ClassVisitor cv, Class<?> cl) {
-      super(Opcodes.ASM7, cv);
+      super(Opcodes.ASM9, cv);
       this.cl = cl;
     }
 

--- a/src/main/java/com/google/monitoring/runtime/instrumentation/VerifyingClassAdapter.java
+++ b/src/main/java/com/google/monitoring/runtime/instrumentation/VerifyingClassAdapter.java
@@ -53,7 +53,7 @@ public class VerifyingClassAdapter extends ClassVisitor {
    * @param className the name of the class being examined.
    */
   public VerifyingClassAdapter(ClassWriter cw, byte[] original, String className) {
-    super(Opcodes.ASM7, cw);
+    super(Opcodes.ASM9, cw);
     state = State.UNKNOWN;
     message = "The class has not finished being examined";
     this.cw = cw;


### PR DESCRIPTION
Related: #51

This fixes warnings related to instrumenting record classes and permitted subclasses, amongst other things, due to requesting ASM7 even after this library was updated to ASM9.2.