### PR TITLE
Added a call to TimeUnit to eagerly load it and it's lambdas, preventing a ClassCircularityError

### DIFF
--- a/src/main/java/com/google/monitoring/runtime/instrumentation/AllocationInstrumenter.java
+++ b/src/main/java/com/google/monitoring/runtime/instrumentation/AllocationInstrumenter.java
@@ -78,6 +78,8 @@ public class AllocationInstrumenter implements ClassFileTransformer {
       Class.forName("sun.security.provider.PolicyFile");
       Class.forName("java.util.ResourceBundle");
       Class.forName("java.util.Date");
+
+      java.util.concurrent.TimeUnit.of(java.time.temporal.ChronoUnit.SECONDS);
     } catch (Throwable t) {
       // NOP
     }


### PR DESCRIPTION
When using the latest 3.3.3 release with JDK17, the instrumenter fails with a ClassCircularityError for java.util.concurrent.TimeUnit$1.

This single-line change fixes the issue and allows the instrumenter to continue properly.